### PR TITLE
Bug fix.

### DIFF
--- a/red/s7.js
+++ b/red/s7.js
@@ -19,7 +19,7 @@ module.exports = function(RED) {
 
     var util = require('util');
     var nodes7 = require('nodes7');
-    var EventEmitter = require('events');
+    var EventEmitter = require('events').EventEmitter;
 
     // ---------- S7 Endpoint ----------
 


### PR DESCRIPTION
EventEmitter was an instance of events due to false import.

The import is changed to

var EventEmitter = require('events').EventEmitter;