### PR TITLE
Added connecting status, show status after node loaded

### DIFF
--- a/red/locales/en-US/s7.json
+++ b/red/locales/en-US/s7.json
@@ -61,7 +61,8 @@
                 "online": "online",
                 "badvalues": "failure",
                 "offline": "offline",
-                "unknown": "unknown"
+                "unknown": "unknown",
+		"connecting": "connecting"
             },
             "verbose": {
                 "default": "Default (command line)",

--- a/red/s7.js
+++ b/red/s7.js
@@ -62,6 +62,13 @@ module.exports = function(RED) {
                     text: RED._("s7.endpoint.status.offline")
                 };
                 break;
+	    case 'connecting':
+		obj = {
+		    fill: 'yellow',
+		    shape: 'dot',
+		    text: RED._("s7.endpoint.status.connecting")
+		};
+		break;
             default:
                 obj = {
                     fill: 'grey',
@@ -269,9 +276,9 @@ module.exports = function(RED) {
 
         node.on('close', closeConnection);
 
-        manageStatus('offline');
 
         function connect(){
+            manageStatus('connecting');
             if (isVerbose) {
                 node.log(RED._("s7.info.connect"));
             }
@@ -327,6 +334,8 @@ module.exports = function(RED) {
         function onEndpointStatus(s) {
             node.status(generateStatus(s.status, statusVal));
         }
+
+	node.status({fill:"yellow",shape:"dot",text:RED._("s7.endpoint.status.connecting")});
 
         node.endpoint.on('__STATUS__', onEndpointStatus);
 
@@ -398,6 +407,8 @@ module.exports = function(RED) {
             node.status(generateStatus(node.endpoint.getStatus(), statusVal));
         }
 
+	node.status({fill:"yellow",shape:"dot",text:RED._("s7.endpoint.status.connecting")});
+
         node.on('input', onNewMsg);
         node.endpoint.on('__STATUS__', onEndpointStatus);
 
@@ -405,6 +416,7 @@ module.exports = function(RED) {
             node.endpoint.removeListener('__STATUS__', onEndpointStatus);
             done();
         });
+
     }
     RED.nodes.registerType("s7 out", S7Out);
 };


### PR DESCRIPTION
Show connecting status on startup of S7in/S7out node.
Solved: If PLC is not connected during node-red ui load, the S7in/S7out node will not show any status until the tcp timeout occurs which will take several minutes.